### PR TITLE
Operate a Zcash Sprout node

### DIFF
--- a/ops/s4-ec2.nix
+++ b/ops/s4-ec2.nix
@@ -1,0 +1,20 @@
+let
+  region = "eu-west-1";
+  accessKeyId = "leastauthority-staging";
+  zcashnode =
+  { config, pkgs, resources, ... }:
+  { deployment.targetEnv = "ec2";
+    deployment.ec2.accessKeyId = accessKeyId;
+    deployment.ec2.region = region;
+    # We need at least 2GB for the Zcash bootstrap process alone.
+    deployment.ec2.ebsInitialRootDiskSize = 10;
+    deployment.ec2.instanceType = "t3.small";
+    deployment.ec2.keyPair = resources.ec2KeyPairs.my-key-pair;
+    deployment.ec2.securityGroups = [ "allow_all" ];
+  };
+in
+{
+  zcashnode = zcashnode;
+  resources.ec2KeyPairs.my-key-pair =
+  { inherit region accessKeyId; };
+}

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -1,0 +1,67 @@
+{
+  network.description = "Web server";
+  zcashnode =
+  { config, pkgs, ... }:
+  { networking.firewall.allowedTCPPorts = [ 18232 18233 ];
+
+    users.users.zcash =
+    { isNormalUser = true;
+      home = "/var/lib/zcashd";
+      description = "Runs a full Zcash node";
+    };
+
+    environment.systemPackages = [
+      # Nix-packaged Zcash distribution - 1.x.
+      pkgs.altcoins.zcash
+      # Provides flock, required by zcash-fetch-params.  Probably a Nix Zcash
+      # package bug that we have to specify it.
+      pkgs.utillinux
+      # Also required by zcash-fetch-params.
+      pkgs.wget
+    ];
+
+    systemd.services.zcashd =
+      # Write the Zcashd configuration file and remember where it is for
+      # later.
+      let conf = pkgs.writeText "zcash.conf"
+      ''
+      # Operate on the test network while we're in development.
+      testnet=1
+      addnode=testnet.z.cash
+
+      # Don't be a miner.
+      gen=0
+    '';
+    in
+    { unitConfig.Documentation = "https://z.cash/";
+      description = "Zcashd running a non-mining Zcash full node";
+      wantedBy    = [ "multi-user.target" ];
+
+      # Get zcash-fetch-params dependencies into its PATH.
+      path = [ pkgs.utillinux pkgs.wget ];
+
+      serviceConfig = {
+        Restart                 = "on-failure";
+        User                    = "zcash";
+        # Nice                    = 19;
+        # IOSchedulingClass       = "idle";
+        PrivateTmp              = "yes";
+        # PrivateNetwork          = "yes";
+        # NoNewPrivileges         = "yes";
+        # ReadWriteDirectories    = "${pkgs.altcoins.zcash}/bin /var/lib/zcashd";
+        # InaccessibleDirectories = "/home";
+        StateDirectory          = "zcashd";
+
+        # Parameters are required before a node can start.  These are fetched
+        # from the network.  This only needs to happen once.  Currently we try
+        # to do it every time we're about to start the node.  Maybe this can
+        # be improved.
+        ExecStartPre            = "${pkgs.altcoins.zcash}/bin/zcash-fetch-params";
+
+        # Rely on $HOME to set the location of most things.  The configuration
+        # file is an exception as it lives in the store.
+        ExecStart               = "${pkgs.altcoins.zcash}/bin/zcashd -conf=${conf}";
+      };
+    };
+  };
+}

--- a/ops/security-groups.tf
+++ b/ops/security-groups.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+    region = "eu-west-1"
+    profile = "leastauthority-staging"
+}
+
+/*
+ * Centralize configuration about which VPC we're operating in.
+ */
+data "aws_vpc" "main" {
+  id = "vpc-76dfc012"
+}
+
+/*
+ * Create a security group that allows all traffic on everything.
+ * TODO: Tighten this up.
+ */
+resource "aws_security_group" "allow_all" {
+  name        = "allow_all"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${data.aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
Fixes #1 

Note this is a Sprout node and not an overwinter node.  As such, it cannot actually talk to any other Zcash nodes.  However, Sprout is what's available in NixOS and I don't want to upgrade from that to Overwinter just to upgrade from Overwinter to Sprout immediately afterwards.  So, for #2, I'll just upgrade from Sprout to Sapling.
