### PR TITLE
Require networking before Zcashd can start

### DIFF
--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -63,6 +63,10 @@
       # Get it to start as a part of the normal boot process.
       wantedBy    = [ "multi-user.target" ];
 
+      # Make sure we have network connectivity before bothering to try to
+      # start zcashd.
+      requires = [ "network-online.target" ];
+
       # Get zcash-fetch-params dependencies into its PATH.
       path = [ pkgs.utillinux pkgs.wget ];
 


### PR DESCRIPTION
It's often harmless if things go the other way, and networking is
usually pretty fast, but in some cases Zcash fetch-params will fail
repeatedly before the network is up and systemd will give up restarting
the Zcash service.

This avoids that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/s4-2.0/28)
<!-- Reviewable:end -->
