### PR TITLE
Let me generate keys for multiple onion services.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,6 @@ Meanwhile, you can generate some throw-away keys::
 
   pip install stem
   mkdir -p ops/secrets/onion-services/v3
-  cd ops/secrets/onion-services/v3
-  ../../../../bin/generate-onion-keys
+  ./bin/generate-onion-keys ops/secrets/onion-services/v3/signup-website
 
 You must have keys before you can use ``nixops`` to deploy the service.

--- a/bin/generate-onion-keys
+++ b/bin/generate-onion-keys
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
+from sys import argv
+
 from stem.control import Controller
 
-def main():
+def main(base_path="signup-website"):
     c = Controller.from_port()
     c.authenticate()
     response = c.create_ephemeral_hidden_service(
@@ -10,14 +12,14 @@ def main():
         key_type="NEW",
         key_content="ED25519-V3",
     )
-    with open("signup-website.hostname", "w") as hostname:
+    with open(base_path + ".hostname", "w") as hostname:
         hostname.write(
             response.service_id + ".onion\n"
         )
-    with open("signup-website.secret", "w") as secret:
+    with open(base_path + ".secret", "w") as secret:
         secret.write(
             "== ed25519v1-secret: type0 ==\x00\x00\x00" +
             response.private_key.decode("base64")
         )
 
-main()
+main(*argv[1:])


### PR DESCRIPTION
There will be multiple static Onion services involved in the deployment - at least the signup website and the main website proxy.  Change the Onion service key generator to be usable to generate more than just one service's key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/s4-2.0/29)
<!-- Reviewable:end -->
