### PR TITLE
Reliable Onion services

### DIFF
--- a/bin/generate-onion-keys
+++ b/bin/generate-onion-keys
@@ -12,10 +12,6 @@ def main(base_path="signup-website"):
         key_type="NEW",
         key_content="ED25519-V3",
     )
-    with open(base_path + ".hostname", "w") as hostname:
-        hostname.write(
-            response.service_id + ".onion\n"
-        )
     with open(base_path + ".secret", "w") as secret:
         secret.write(
             "== ed25519v1-secret: type0 ==\x00\x00\x00" +

--- a/onion-service-endpoint/LICENSE
+++ b/onion-service-endpoint/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Least Authority TFA GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/onion-service-endpoint/setup.cfg
+++ b/onion-service-endpoint/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/onion-service-endpoint/setup.py
+++ b/onion-service-endpoint/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Copyright Least Authority TFA GmbH
+# See LICENSE for details.
+
+import setuptools
+
+setuptools.setup(
+    name="txxonion",
+    version="0.1",
+    description="A Twisted server string endpoint description parser for Onion services.",
+    author="txxonion Developers",
+    url="https://leastauthority.com/",
+    license="MIT",
+    package_dir={"": "src"},
+    packages=setuptools.find_packages(where="src") + ["twisted.plugins"],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        "zope.interface",
+        "twisted",
+        "txtorcon",
+    ],
+)

--- a/onion-service-endpoint/src/twisted/plugins/onion_service_endpoint_dropin.py
+++ b/onion-service-endpoint/src/twisted/plugins/onion_service_endpoint_dropin.py
@@ -1,0 +1,54 @@
+from binascii import b2a_base64
+from zope.interface import implementer
+from twisted.plugin import IPlugin
+from twisted.internet.interfaces import IStreamServerEndpointStringParser
+from twisted.internet.endpoints import clientFromString
+
+from txtorcon.endpoints import (
+    TCPHiddenServiceEndpoint,
+)
+
+@implementer(IStreamServerEndpointStringParser, IPlugin)
+class TCPHiddenServiceEndpointParser(object):
+    prefix = "x-onion"
+
+    def parseStreamServer(
+            self,
+            reactor,
+            public_port,
+            privateKeyPath,
+            localPort=None,
+            controlPort=None,
+    ):
+        with file(privateKeyPath) as privateKeyFile:
+            privateKey = privateKeyFile.read()
+        formattedPrivateKey = (
+            "ED25519-V3:" +
+            b2a_base64(privateKey[len("== ed25519v1-secret: type0 ==\x00\x00\x00"):]).strip()
+        )
+        public_port = int(public_port)
+
+        if localPort is not None:
+            localPort = int(localPort)
+
+        if controlPort:
+            try:
+                ep = clientFromString(
+                    reactor, "tcp:host=127.0.0.1:port=%d" % int(controlPort))
+            except ValueError:
+                ep = clientFromString(reactor, "unix:path=%s" % controlPort)
+            construct = TCPHiddenServiceEndpoint.system_tor
+        else:
+            ep = None
+            construct = TCPHiddenServiceEndpoint.global_tor
+
+        return construct(
+            reactor,
+            ep,
+            public_port,
+            local_port=localPort,
+            private_key=formattedPrivateKey,
+            version=3,
+        )
+
+parser = TCPHiddenServiceEndpointParser()

--- a/ops/nixpkgs-overlays.nix
+++ b/ops/nixpkgs-overlays.nix
@@ -1,0 +1,10 @@
+self: super:
+{ tor = super.tor.overrideAttrs (old:
+    rec { name = "tor-0.3.5.2-alpha";
+          src = super.fetchurl
+          { url = "https://www.torproject.org/dist/tor-0.3.5.2-alpha.tar.gz";
+            sha256 = "16pc99sam4lvgnmvb8sh1k89hskrkl1p79wda93pwdcyry5mvmx4";
+          };
+        }
+  );
+}

--- a/ops/nixpkgs-overlays.nix
+++ b/ops/nixpkgs-overlays.nix
@@ -1,5 +1,11 @@
 self: super:
-{ tor = super.tor.overrideAttrs (old:
+{
+  # Supply a newer version of Tor than is currently available in nixpkgs.
+  # This is necessary to make restarting ephemeral Onion services reliable.
+  # Old versions of Tor sometimes fail to re-upload the descriptor or even if
+  # they succeed in re-uploading it the service remains mysteriously
+  # unavailable.
+  tor = super.tor.overrideAttrs (old:
     rec { name = "tor-0.3.5.2-alpha";
           src = super.fetchurl
           { url = "https://www.torproject.org/dist/tor-0.3.5.2-alpha.tar.gz";

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -136,6 +136,9 @@
       # protecting our location privacy.  This should offer some amount of
       # performance improvement as well due to the reduced number of hops to
       # reach the service.
+      #
+      # However, https://github.com/meejah/txtorcon/issues/315
+      #
       # HiddenServiceSingleHopMode 1
       # HiddenServiceNonAnonymousMode 1
 

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -12,6 +12,7 @@
   zcashnode =
   { lib, pkgs, ... }:
   let zcash = pkgs.callPackage ./zcash/default.nix { };
+      txxonion = pkgs.callPackage ./txxonion.nix { };
       s4signupwebsite = pkgs.callPackage ./s4signupwebsite.nix { };
       torControlPort = 9051;
       websiteOnion3Dir = "/run/onion/v3/signup-website";
@@ -200,7 +201,7 @@
     { unitConfig.Documentation = "https://leastauthority.com/";
       description = "The S4 2.0 signup website.";
 
-      path = [ (pkgs.python27.withPackages (ps: [ ps.twisted ps.txtorcon ])) ];
+      path = [ (pkgs.python27.withPackages (ps: [ ps.twisted ps.txtorcon txxonion ])) ];
 
       # Get it to start as a part of the normal boot process.
       wantedBy    = [ "multi-user.target" ];

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -15,7 +15,6 @@
       txxonion = pkgs.callPackage ./txxonion.nix { };
       s4signupwebsite = pkgs.callPackage ./s4signupwebsite.nix { };
       torControlPort = 9051;
-      websiteOnion3Dir = "/run/onion/v3/signup-website";
   in
   # Allow the two Zcash protocol ports.
   { networking.firewall.allowedTCPPorts = [ 18232 18233 ];

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -2,6 +2,13 @@
 {
   network.description = "Zcash server";
 
+  defaults = { ... }:
+  {
+    # Arrange for some packages to be overridden with different versions on
+    # all machines.
+    nixpkgs.overlays = [ (import ./nixpkgs-overlays.nix) ];
+  };
+
   zcashnode =
   { lib, pkgs, ... }:
   let zcash = pkgs.callPackage ./zcash/default.nix { };

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -191,6 +191,12 @@
       # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
       after = [ "tor.service" "signup-website-tor-onion-service-v3.secret-key.service" ];
 
+      # Run an Onion-to-HTTPS port forward to expose the website at an Onion
+      # service address.  Use the x-onion endpoint here so that we can refer
+      # directly to the key file.  This is nicer than using the "hidden
+      # service directory" feature which requires a more complex directory
+      # structure, requires us to supply more files, and has weird
+      # file-rewriting behavior we don't want.
       script = ''
       twist --log-format=text web \
         --path ${s4signupwebsite} \

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -159,8 +159,6 @@
       { ReadWritePaths =
         [ # Let it keep track of its various internal state.
           "/var/lib/tor"
-          # Let it generate the public key file for the onion service key.
-          "/run/onion"
         ];
       };
     };
@@ -174,28 +172,6 @@
       group = "tor";
       permissions = "0600";
     };
-    deployment.keys."signup-website-tor-onion-service-v3.hostname" =
-    { keyFile = ./secrets/onion-services/v3/signup-website.hostname;
-      user = "tor";
-      group = "tor";
-      permissions = "0600";
-    };
-
-    # Construct a directory with a suitable structure for consumption by Tor
-    # as an Onion service configuration directory.  We can only use Nix's
-    # deployment.keys feature to create a flat hierarchy in /run/keys so we
-    # need systemd's help to create the structure required by Tor.
-    #
-    # https://nixos.org/nixos/manual/options.html#opt-systemd.tmpfiles.rules
-    systemd.tmpfiles.rules =
-    [ "d  /run/onion                                0700 tor tor - -"
-      "d  /run/onion/v3                             0700 tor tor - -"
-      "d  ${websiteOnion3Dir}                       0700 tor tor - -"
-
-      "L+ ${websiteOnion3Dir}/hs_ed25519_secret_key -    -   -   - /run/keys/signup-website-tor-onion-service-v3.secret"
-      "L+ ${websiteOnion3Dir}/hostname              -    -   -   - /run/keys/signup-website-tor-onion-service-v3.hostname"
-    ];
-
     /*
      * Operate a static website allowing user signup, exposed via the Tor
      * hidden service.

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -136,8 +136,8 @@
       # protecting our location privacy.  This should offer some amount of
       # performance improvement as well due to the reduced number of hops to
       # reach the service.
-      HiddenServiceSingleHopMode 1
-      HiddenServiceNonAnonymousMode 1
+      # HiddenServiceSingleHopMode 1
+      # HiddenServiceNonAnonymousMode 1
 
       # We don't make outgoing Tor connections via the SOCKS proxy.  Disable
       # it.  This is also necessary to use HiddenServiceNonAnonymousMode.
@@ -215,7 +215,7 @@
       script = ''
       twist --log-format=text web \
         --path ${s4signupwebsite} \
-        --port onion:version=3:public_port=80:controlPort=${toString torControlPort}:hiddenServiceDir=${websiteOnion3Dir}
+        --port x-onion:public_port=80:controlPort=${toString torControlPort}:privateKeyPath=/run/keys/signup-website-tor-onion-service-v3.secret
       '';
     };
   };

--- a/ops/tor/default.nix
+++ b/ops/tor/default.nix
@@ -1,9 +1,0 @@
-{ tor, fetchurl }:
-tor.overrideAttrs (old:
-rec { name = "tor-0.3.5.2-alpha";
-      src = fetchurl
-      { url = "https://www.torproject.org/dist/tor-0.3.5.2-alpha.tar.gz";
-        sha256 = "16pc99sam4lvgnmvb8sh1k89hskrkl1p79wda93pwdcyry5mvmx4";
-      };
-    }
-)

--- a/ops/tor/default.nix
+++ b/ops/tor/default.nix
@@ -1,0 +1,9 @@
+{ tor, fetchurl }:
+tor.overrideAttrs (old:
+rec { name = "tor-0.3.5.2-alpha";
+      src = fetchurl
+      { url = "https://www.torproject.org/dist/tor-0.3.5.2-alpha.tar.gz";
+        sha256 = "16pc99sam4lvgnmvb8sh1k89hskrkl1p79wda93pwdcyry5mvmx4";
+      };
+    }
+)

--- a/ops/txxonion.nix
+++ b/ops/txxonion.nix
@@ -1,3 +1,6 @@
+# Package txxonion for ourselves to use.  This provides an endpoint that lets
+# us provide Onion service keys more easily than the onion endpoint in
+# txtorcon.
 { python }:
 python.pkgs.buildPythonPackage
 rec { pname = "txxonion";

--- a/ops/txxonion.nix
+++ b/ops/txxonion.nix
@@ -1,0 +1,11 @@
+{ python }:
+python.pkgs.buildPythonPackage
+rec { pname = "txxonion";
+      version = "0.1";
+      src = python.pkgs.fetchPypi
+      { inherit pname version;
+        extension = "tar.gz";
+        sha256 = "0ahfkmrh6mwvxz0jah0m8la5dzf2ns8xj6xv1zgb9mnprqpwvrk4";
+      };
+      propagatedBuildInputs = [ python.pkgs.zope_interface python.pkgs.twisted python.pkgs.txtorcon ];
+}


### PR DESCRIPTION
Fixes #26

The core of the fix seems to be upgrading to a new-enough Tor.  Also included here, though, is a new endpoint that lets us point directly at a key file and bypass the cumbersome requirements of Tor's "hidden service directory" feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/s4-2.0/30)
<!-- Reviewable:end -->
